### PR TITLE
Use K8s Cluster Network for Discord Bot Requests to  API and FCP

### DIFF
--- a/.github/workflows/generate-configmaps.yaml
+++ b/.github/workflows/generate-configmaps.yaml
@@ -1,7 +1,9 @@
-
 name: Generate and Update ConfigMap
 
-on: [push]
+on:
+  push:
+    branches:
+      - main
 
 jobs:
   push:
@@ -11,7 +13,7 @@ jobs:
       - name: Setup Go ${{ matrix.go-version }}
         uses: actions/setup-go@v4
         with:
-          go-version: '1.23.x'
+          go-version: "1.23.x"
       - name: Build Generator
         run: go build -o bin/generator ./generator/generator.go
       - name: Generate ConfigMap
@@ -21,8 +23,8 @@ jobs:
       - name: Checkout GitOps Repository
         uses: actions/checkout@v4
         with:
-          repository: 'the-pilot-club/gitops'
-          path: gitops  # Choose a suitable directory name
+          repository: "the-pilot-club/gitops"
+          path: gitops # Choose a suitable directory name
           token: ${{ secrets.G_TOKEN }}
 
       # Update the ConfigMap (Adapt paths as needed)
@@ -33,9 +35,13 @@ jobs:
       # Commit and Push to the Target Repository
       - name: Commit and Push Changes
         run: |
-          cd gitops # Move into the checked out repository
+          cd gitops
           git config --global user.email "webdev@thepilotclub.org"
           git config --global user.name "thepilotclub"
           git add discord-bot-v3/configmap.yaml
+          if git diff --staged --quiet; then
+            echo "No changes to commit, skipping push"
+            exit 0
+          fi
           git commit -m "Update configmap.yaml from generator"
           git push origin main

--- a/config/dev.yaml
+++ b/config/dev.yaml
@@ -33,9 +33,9 @@ emojis:
     id: :giveaway:1225560451279097926
 baseurl:
   - name: FCP
-    link: https://flightcrew-beta.thepilotclub.org
+    link: http://fcpbeta.fcp.svc.cluster.local
   - name: Internal API
-    link: https://api.thepilotclub.org
+    link: http://ts-api-beta.api.svc.cluster.local:3000
 role_rewards:
   - role_name: Frequent Flyer 
     role_id: 1148307481290866804

--- a/config/prod.yaml
+++ b/config/prod.yaml
@@ -15,6 +15,6 @@ emojis:
     id: :tpc:845075689241051138
 baseurl:
   - name: FCP
-    link: https://flightcrew.thepilotclub.org
+    link: http://fcp.fcpprod.svc.cluster.local
   - name: Internal API
-    link: https://api.thepilotclub.org
+    link: http://ts-api-beta.api.svc.cluster.local:3000

--- a/manifest/configmap.yaml
+++ b/manifest/configmap.yaml
@@ -21,9 +21,9 @@ data:
           id: :giveaway:1225560451279097926
       baseurl:
         - name: FCP
-          link: https://flightcrew-beta.thepilotclub.org
+          link: http://fcpbeta.fcp.svc.cluster.local
         - name: Internal API
-          link: https://api.thepilotclub.org
+          link: http://ts-api-beta.api.svc.cluster.local:3000
     prod.yaml: |
       id: 830201397974663229
       name: The Pilot Club
@@ -39,6 +39,6 @@ data:
           id: 830209982770708500
       baseurl:
         - name: FCP
-          link: https://flightcrew.thepilotclub.org
+          link: http://fcp.fcpprod.svc.cluster.local
         - name: Internal API
-          link: https://api.thepilotclub.org
+          link: http://ts-api-beta.api.svc.cluster.local:3000


### PR DESCRIPTION
> [!NOTE]
> The changes to the config maps have already entered the `gitops` repository as they were done so automatically by the workflow when I opened this branch.  

Make requests from discord bot pods directly to API / FCP pods using the k8s cluster network. This will reduce request latency and reduce our ingress / egress.

**Github Workflow Update**

I've included a Github Workflow update that ensures the config map changes only happen when there is a push to the main branch.